### PR TITLE
Keyboard shortcuts to the projects page.

### DIFF
--- a/components/shared/kbd.tsx
+++ b/components/shared/kbd.tsx
@@ -1,6 +1,6 @@
-import { ForwardedRef, forwardRef } from 'react';
+import { ForwardedRef, forwardRef, useState } from 'react';
 import cn from 'clsx';
-import { useDownKeysStore } from '@/lib/stores/use-down-keys-store';
+import { useHotkeysHandler } from '@/utils/use-hotkeys-handler';
 
 type KBDProps = {
   children: React.ReactNode;
@@ -8,9 +8,13 @@ type KBDProps = {
 
 const KBD: React.FC<KBDProps> = forwardRef(
   ({ children, className }, ref: ForwardedRef<HTMLUnknownElement>) => {
-    const downKeys = useDownKeysStore(state => state.downKeys);
+    const [isDown, setIsDown] = useState(false)
     const key = children as string;
-    const isDown = downKeys.has(key);
+    useHotkeysHandler([key], () => {
+      setIsDown(true)
+    }, () => {
+      setIsDown(false)
+    },);
     return (
       <kbd
         className={cn(

--- a/layouts/header.tsx
+++ b/layouts/header.tsx
@@ -1,44 +1,19 @@
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import { signOut, useSession } from 'next-auth/react';
 import KBD from '@/components/shared/kbd';
-import { useDownKeysStore } from '@/lib/stores/use-down-keys-store';
+import { useHotkeysHandler } from '@/utils/use-hotkeys-handler';
 
 export default function Header() {
   const session = useSession();
   const router = useRouter();
-  const { downKeys, addKey, clearKeys } = useDownKeysStore();
+  useHotkeysHandler(['p'], () => {
+    if (router.pathname !== '/projects') router.push('/projects');
+  });
 
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      // Add the key to the downKeys map.
-      addKey(e.key);
-
-      // If the user is holding down the "p" key, go to the projects page.
-      if (e.key === 'p') {
-        // If the route is already "/projects", don't do anything.
-        if (router.pathname !== '/projects') router.push('/projects');
-      }
-      // If the user is holding down the "h" key, go to the home page.
-      if (e.key === 'h') {
-        // If the route is already "/", don't do anything.
-        if (router.pathname !== '/') router.push('/');
-      }
-    };
-
-    const up = (e: KeyboardEvent) => {
-      // Remove the key from the downKeys map.
-      clearKeys();
-    };
-
-    document.addEventListener('keydown', down);
-    document.addEventListener('keyup', up);
-    return () => {
-      document.removeEventListener('keydown', down);
-      document.removeEventListener('keyup', up);
-    };
-  }, [router, addKey, clearKeys, downKeys]);
+  useHotkeysHandler(['h'], () => {
+    if (router.pathname !== '/') router.push('/');
+  });
 
   return (
     <header className="mb-10">

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -38,19 +38,14 @@ export default function Projects() {
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       projects?.forEach((project, index) => {
-        if (
-          e.key === `${index + 1}` &&
-          (e.ctrlKey || e.metaKey) &&
-          e.shiftKey
-        ) {
-          prefetchProjectData(project.slug);
+        if (e.key === `${index + 1}`) {
           router.push(`/${project.slug}`);
         }
       });
     };
     document.addEventListener('keydown', down);
     return () => document.removeEventListener('keydown', down);
-  }, [projects, prefetchProjectData, router]);
+  }, [projects, router]);
 
   return (
     <Container>
@@ -65,8 +60,8 @@ export default function Projects() {
                 <NextLink
                   href={`/${project.slug}`}
                   key={project.id}
-                  onMouseEnter={async () => prefetchProjectData(project.slug)}
-                  onFocus={async () => prefetchProjectData(project.slug)}
+                  onMouseEnter={() => prefetchProjectData(project.slug)}
+                  onFocus={() => prefetchProjectData(project.slug)}
                 >
                   <div className="rounded-md border border-gray-100/40 bg-white p-5 shadow transition hover:shadow-md">
                     <p>{project.name}</p>

--- a/utils/use-hotkeys-handler.ts
+++ b/utils/use-hotkeys-handler.ts
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo } from 'react';
 
 type KeyHandler = (keys: Set<string>) => void;
 
-export function useHotkeysHandler(keys: string[], handler: KeyHandler) {
+export function useHotkeysHandler(
+  keys: string[],
+  handler: KeyHandler,
+  keyUpHandler?: KeyHandler
+) {
   const downKeys = useMemo(() => new Set<string>(), []);
 
   const downHandler = useCallback(
@@ -18,8 +22,11 @@ export function useHotkeysHandler(keys: string[], handler: KeyHandler) {
   const upHandler = useCallback(
     (event: KeyboardEvent) => {
       downKeys.delete(event.key);
+      if (keyUpHandler) {
+        keyUpHandler(downKeys);
+      }
     },
-    [downKeys]
+    [downKeys, keyUpHandler]
   );
 
   useEffect(() => {

--- a/utils/use-hotkeys-handler.ts
+++ b/utils/use-hotkeys-handler.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+type KeyHandler = (keys: Set<string>) => void;
+
+export function useHotkeysHandler(keys: string[], handler: KeyHandler) {
+  const downKeys = useMemo(() => new Set<string>(), []);
+
+  const downHandler = useCallback(
+    (event: KeyboardEvent) => {
+      downKeys.add(event.key);
+      if (keys.every(key => downKeys.has(key))) {
+        handler(downKeys);
+      }
+    },
+    [downKeys, handler, keys]
+  );
+
+  const upHandler = useCallback(
+    (event: KeyboardEvent) => {
+      downKeys.delete(event.key);
+    },
+    [downKeys]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', downHandler);
+    document.addEventListener('keyup', upHandler);
+    return () => {
+      document.removeEventListener('keydown', downHandler);
+      document.removeEventListener('keyup', upHandler);
+    };
+  }, [downHandler, upHandler]);
+
+  return downKeys;
+}


### PR DESCRIPTION
This adds keyboard shortcuts to the projects page.

The shortcuts are:

- `1`: Go to the first project
- `2`: Go to the second project
- `3`: Go to the third project
- `4`: Go to the fourth project
- `5`: Go to the fifth project
- `6`: Go to the sixth project
- `7`: Go to the seventh project
- `8`: Go to the eighth project
- `9`: Go to the ninth project
- `0`: Go to the tenth project

The shortcuts are only available when the projects page is focused.

The shortcuts are not available on mobile devices.