### PR TITLE
Fix scrolling to bottom of chat 

### DIFF
--- a/components/projects/chatting.tsx
+++ b/components/projects/chatting.tsx
@@ -89,11 +89,11 @@ function Chat() {
         </div>
         <div
           className={cn(
-            'pointer-events-none absolute bottom-0 h-full w-full touch-none border border-red-200',
+            'pointer-events-none absolute bottom-0 h-full w-full touch-none',
             overlay.top &&
-              'before:absolute before:top-0 before:h-10 before:w-full before:bg-red-200',
+              'before:absolute before:top-0 before:h-20 before:w-full before:bg-gradient-to-b before:from-white before:to-transparent',
             overlay.bottom &&
-              'after:absolute after:bottom-0 after:h-10 after:w-full after:bg-red-200'
+              'after:absolute after:bottom-0 after:h-20 after:w-full after:bg-gradient-to-t after:from-white after:to-transparent'
           )}
         ></div>
       </div>

--- a/components/projects/chatting.tsx
+++ b/components/projects/chatting.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import cn from 'clsx';
 import {
   PusherProvider,
   useCurrentMemberCount,
@@ -9,6 +10,10 @@ import useProject from '@/utils/use-project';
 function Chat() {
   const ref = useRef<HTMLDivElement>(null);
   const { project } = useProject();
+  const [overlay, setOverlay] = useState({
+    top: false,
+    bottom: false,
+  });
   const [messages, setMessages] = useState<
     {
       sender: string;
@@ -24,27 +29,73 @@ function Chat() {
     ref.current?.scrollTo(0, ref.current.scrollHeight);
   }, [messages]);
 
+  useEffect(() => {
+    const target = ref.current;
+    if (!target) return;
+
+    if (target.scrollHeight > target.clientHeight)
+      setOverlay(prev => ({ ...prev, top: true }));
+
+    console.log(target.scrollHeight, target.clientHeight);
+    const scroll = (e: Event) => {
+      if (target.scrollTop === 0) {
+        console.log('Scrolled to top');
+        setOverlay(prev => ({ top: false, bottom: true }));
+      } else if (
+        target.scrollTop + target.clientHeight ===
+        target.scrollHeight
+      ) {
+        console.log('Scrolled to bottom');
+        setOverlay(prev => ({ top: true, bottom: false }));
+      } else {
+        setOverlay(prev => ({ top: true, bottom: true }));
+      }
+    };
+
+    target.addEventListener('scroll', scroll);
+    return () => target.removeEventListener('scroll', scroll);
+  }, []);
+
   const active = useCurrentMemberCount();
-  console.log(active);
+  console.log(active, overlay);
 
   return (
     <main className="flex max-h-[356px] min-h-full flex-col">
       <div className="w-full rounded bg-gray-100 p-2 font-semibold text-gray-800">
         {active} active users.
       </div>
-      <div className="h-[calc(100%-77px)] overflow-y-auto" ref={ref}>
-        <ul className="flex flex-col justify-end divide-y divide-gray-200 py-2">
-          {messages.map((message, index) => (
-            <li key={index}>
-              <div className="p-2">
-                <p className="text-xs font-medium text-gray-600">
-                  {message.sender}
-                </p>
-                <p className="font-medium">{message.message}</p>
-              </div>
-            </li>
-          ))}
-        </ul>
+      <div className="relative h-[calc(100%-77px)] overflow-hidden">
+        <div className="h-full overflow-y-auto" ref={ref}>
+          <ul className="flex flex-col justify-end divide-y divide-gray-200 py-2">
+            {/* {messages.map((message, index) => (
+              <li key={index}>
+                <div className="p-2">
+                  <p className="text-xs font-medium text-gray-600">
+                    {message.sender}
+                  </p>
+                  <p className="font-medium">{message.message}</p>
+                </div>
+              </li>
+            ))} */}
+            {new Array(20).fill(0).map((_, index) => (
+              <li key={index}>
+                <div className="p-2">
+                  <p className="text-xs font-medium text-gray-600">{index}</p>
+                  <p className="font-medium">{index}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div
+          className={cn(
+            'pointer-events-none absolute bottom-0 h-full w-full touch-none border border-red-200',
+            overlay.top &&
+              'before:absolute before:top-0 before:h-10 before:w-full before:bg-red-200',
+            overlay.bottom &&
+              'after:absolute after:bottom-0 after:h-10 after:w-full after:bg-red-200'
+          )}
+        ></div>
       </div>
       <form
         onSubmit={e => {

--- a/components/projects/chatting.tsx
+++ b/components/projects/chatting.tsx
@@ -26,7 +26,10 @@ function Chat() {
   });
 
   useEffect(() => {
-    ref.current?.scrollTo(0, ref.current.scrollHeight);
+    ref.current?.scrollTo(
+      0,
+      ref.current.scrollHeight - ref.current.clientHeight
+    );
   }, [messages]);
 
   useEffect(() => {
@@ -36,28 +39,31 @@ function Chat() {
     if (target.scrollHeight > target.clientHeight)
       setOverlay(prev => ({ ...prev, top: true }));
 
-    console.log(target.scrollHeight, target.clientHeight);
     const scroll = (e: Event) => {
       if (target.scrollTop === 0) {
         console.log('Scrolled to top');
         setOverlay(prev => ({ top: false, bottom: true }));
       } else if (
-        target.scrollTop + target.clientHeight ===
+        Math.round(target.scrollTop + target.clientHeight) ===
         target.scrollHeight
       ) {
         console.log('Scrolled to bottom');
         setOverlay(prev => ({ top: true, bottom: false }));
-      } else {
+      } else if (target.scrollTop + target.clientHeight < target.scrollHeight) {
+        console.log('Scrolled to middle');
         setOverlay(prev => ({ top: true, bottom: true }));
+      } else {
+        console.log('Scrolled to unknown');
+        setOverlay(prev => ({ top: false, bottom: false }));
       }
     };
 
     target.addEventListener('scroll', scroll);
     return () => target.removeEventListener('scroll', scroll);
-  }, []);
+  }, [messages]);
 
   const active = useCurrentMemberCount();
-  console.log(active, overlay);
+  // console.log(active, overlay);
 
   return (
     <main className="flex max-h-[356px] min-h-full flex-col">
@@ -66,8 +72,8 @@ function Chat() {
       </div>
       <div className="relative h-[calc(100%-77px)] overflow-hidden">
         <div className="h-full overflow-y-auto" ref={ref}>
-          <ul className="flex flex-col justify-end divide-y divide-gray-200 py-2">
-            {/* {messages.map((message, index) => (
+          <ul className="flex flex-col justify-end divide-y divide-gray-200">
+            {messages.map((message, index) => (
               <li key={index}>
                 <div className="p-2">
                   <p className="text-xs font-medium text-gray-600">
@@ -76,18 +82,19 @@ function Chat() {
                   <p className="font-medium">{message.message}</p>
                 </div>
               </li>
-            ))} */}
-            {new Array(20).fill(0).map((_, index) => (
+            ))}
+            {/* {new Array(20).fill(0).map((_, index) => (
               <li key={index}>
                 <div className="p-2">
                   <p className="text-xs font-medium text-gray-600">{index}</p>
                   <p className="font-medium">{index}</p>
                 </div>
               </li>
-            ))}
+            ))} */}
           </ul>
         </div>
         <div
+          aria-hidden
           className={cn(
             'pointer-events-none absolute bottom-0 h-full w-full touch-none',
             overlay.top &&
@@ -111,7 +118,7 @@ function Chat() {
           });
         }}
       >
-        <div className="flex items-center gap-2">
+        <div className="relative z-10 flex items-center gap-2">
           <input
             type="text"
             name="message"


### PR DESCRIPTION
The previous implementation was scrolling to the bottom of the chat window, but it was not taking into account the height of the chat window. This meant that the last message would be hidden if the chat window were not full height.

This commit fixes the issue by scrolling to the bottom of the chat window minus the height of the chat window.