### PR TITLE
Add Pusher server configuration

### DIFF
--- a/lib/stores/private-pusher-store.tsx
+++ b/lib/stores/private-pusher-store.tsx
@@ -17,9 +17,44 @@ interface PusherZustandStore {
   privateChannel: PresenceChannel;
 }
 
+const pusher_key = process.env.NEXT_PUBLIC_PUSHER_APP_KEY!;
+const pusher_server_host = process.env.NEXT_PUBLIC_PUSHER_SERVER_HOST!;
+const pusher_server_port = parseInt(
+  process.env.NEXT_PUBLIC_PUSHER_SERVER_PORT!,
+  10
+);
+const pusher_server_tls = process.env.NEXT_PUBLIC_PUSHER_SERVER_TLS === 'true';
+const pusher_server_cluster = 'us2';
+
 const createPusherStore = (slug: string) => {
-  let pusherClient = Pusher.instances[0];
-  pusherClient.connect();
+  let pusherClient: Pusher;
+  if (Pusher.instances.length) {
+    pusherClient = Pusher.instances[0];
+    pusherClient.connect();
+  } else {
+    const user_id = `${getRandomId()}`;
+    pusherClient = new Pusher(pusher_key, {
+      cluster: pusher_server_cluster,
+      wsHost: pusher_server_host,
+      wsPort: pusher_server_port,
+      enabledTransports: pusher_server_tls ? ['ws', 'wss'] : ['ws'],
+      forceTLS: pusher_server_tls,
+      disableStats: true,
+      authEndpoint: '/api/pusher/auth-channel',
+      userAuthentication: {
+        endpoint: '/api/pusher/auth-user',
+        transport: 'jsonp',
+        headers: {
+          user_id,
+        },
+      },
+      auth: {
+        headers: {
+          user_id,
+        },
+      },
+    });
+  }
 
   const privateChannel = pusherClient.subscribe(
     `private-${slug}`

--- a/lib/stores/pusher-store.tsx
+++ b/lib/stores/pusher-store.tsx
@@ -10,6 +10,7 @@
 import Pusher, { Channel, PresenceChannel } from 'pusher-js';
 import { useStore } from 'zustand';
 import { StoreApi, createStore } from 'zustand/vanilla';
+import { getRandomId } from '@/utils/get-random-id';
 import { usePusherClient } from './pusher-wrapper-store';
 
 interface PusherZustandStore {
@@ -20,9 +21,44 @@ interface PusherZustandStore {
   isSubscribed: boolean;
 }
 
+const pusher_key = process.env.NEXT_PUBLIC_PUSHER_APP_KEY!;
+const pusher_server_host = process.env.NEXT_PUBLIC_PUSHER_SERVER_HOST!;
+const pusher_server_port = parseInt(
+  process.env.NEXT_PUBLIC_PUSHER_SERVER_PORT!,
+  10
+);
+const pusher_server_tls = process.env.NEXT_PUBLIC_PUSHER_SERVER_TLS === 'true';
+const pusher_server_cluster = 'us2';
+
 const createPusherStore = (slug: string) => {
-  let pusherClient = Pusher.instances[0];
-  pusherClient.connect();
+  let pusherClient: Pusher;
+  if (Pusher.instances.length) {
+    pusherClient = Pusher.instances[0];
+    pusherClient.connect();
+  } else {
+    const user_id = `${getRandomId()}`;
+    pusherClient = new Pusher(pusher_key, {
+      cluster: pusher_server_cluster,
+      wsHost: pusher_server_host,
+      wsPort: pusher_server_port,
+      enabledTransports: pusher_server_tls ? ['ws', 'wss'] : ['ws'],
+      forceTLS: pusher_server_tls,
+      disableStats: true,
+      authEndpoint: '/api/pusher/auth-channel',
+      userAuthentication: {
+        endpoint: '/api/pusher/auth-user',
+        transport: 'jsonp',
+        headers: {
+          user_id,
+        },
+      },
+      auth: {
+        headers: {
+          user_id,
+        },
+      },
+    });
+  }
 
   const presenceChannel = pusherClient.subscribe(
     `presence-${slug}`


### PR DESCRIPTION
This commit adds the Pusher server configuration to the client-side code.

The configuration is read from the environment variables.

The configuration is used to create a new Pusher instance if there is no existing instance.