### PR TITLE
Add lodash.throttle to improve scroll performance

### DIFF
--- a/components/chat/messages.tsx
+++ b/components/chat/messages.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
+import throttle from 'lodash.throttle';
 import { useSession } from 'next-auth/react';
 import { useSubscribeToEvent } from '@/lib/stores/pusher-store';
 import { cn } from '@/utils/cn';
@@ -63,7 +64,7 @@ export default function Messages() {
     if (target.scrollHeight > target.clientHeight)
       setOverlay(prev => ({ ...prev, top: true }));
 
-    const scroll = (e: Event) => {
+    const handleScroll = throttle((e: Event) => {
       if (target.scrollTop === 0) {
         // console.log('Scrolled to top');
         setOverlay(prev => ({ top: false, bottom: true }));
@@ -80,10 +81,11 @@ export default function Messages() {
         // console.log('Scrolled to unknown');
         setOverlay(prev => ({ top: false, bottom: false }));
       }
-    };
 
-    target.addEventListener('scroll', scroll);
-    return () => target.removeEventListener('scroll', scroll);
+      console.log('Re-rendering')
+    }, 500);
+    target.addEventListener('scroll', handleScroll);
+    return () => target.removeEventListener('scroll', handleScroll);
   }, []);
 
   return (
@@ -119,10 +121,10 @@ export default function Messages() {
         aria-hidden
         className={cn(
           'pointer-events-none absolute bottom-0 h-full w-full touch-none',
-          overlay.top &&
-            'before:absolute before:top-0 before:h-20 before:w-full before:bg-gradient-to-b before:from-white before:to-transparent',
-          overlay.bottom &&
-            'after:absolute after:bottom-0 after:h-20 after:w-full after:bg-gradient-to-t after:from-white after:to-transparent'
+          'before:absolute before:top-0 before:h-20 before:w-full before:origin-top before:bg-gradient-to-b before:from-white before:to-transparent before:transition-all before:duration-500 before:ease-in-out',
+          'after:absolute after:bottom-0 after:left-0 after:h-20 after:w-full after:origin-bottom after:bg-gradient-to-t after:from-white after:to-transparent after:transition-all after:duration-500 after:ease-in-out',
+          overlay.top ? 'before:scale-y-100' : 'before:scale-y-0',
+          overlay.bottom ? 'after:scale-y-100' : 'after:scale-y-0'
         )}
       />
     </div>

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^3.7.1",
     "@tailwindcss/forms": "^0.5.3",
+    "@types/lodash.throttle": "^4.1.7",
     "@types/mjml": "^4.7.0",
     "@types/mjml-react": "^2.0.6",
     "@types/ms": "^0.7.31",
@@ -55,6 +56,7 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-tailwindcss": "^3.8.3",
+    "lodash.throttle": "^4.1.1",
     "mailing": "^0.9.10",
     "postcss": "^8.4.21",
     "prettier": "^2.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ specifiers:
   '@radix-ui/react-popover': ^1.0.3
   '@tailwindcss/forms': ^0.5.3
   '@tanstack/react-query': ^4.24.9
+  '@types/lodash.throttle': ^4.1.7
   '@types/mjml': ^4.7.0
   '@types/mjml-react': ^2.0.6
   '@types/ms': ^0.7.31
@@ -25,6 +26,7 @@ specifiers:
   eslint-config-prettier: ^8.6.0
   eslint-plugin-react: ^7.32.2
   eslint-plugin-tailwindcss: ^3.8.3
+  lodash.throttle: ^4.1.1
   mailing: ^0.9.10
   mailing-core: ^0.9.10
   mjml: ^4.13.0
@@ -89,6 +91,7 @@ dependencies:
 devDependencies:
   '@ianvs/prettier-plugin-sort-imports': 3.7.1_prettier@2.8.4
   '@tailwindcss/forms': 0.5.3_tailwindcss@3.2.7
+  '@types/lodash.throttle': 4.1.7
   '@types/mjml': 4.7.0
   '@types/mjml-react': 2.0.6
   '@types/ms': 0.7.31
@@ -98,6 +101,7 @@ devDependencies:
   eslint-config-prettier: 8.6.0_eslint@8.29.0
   eslint-plugin-react: 7.32.2_eslint@8.29.0
   eslint-plugin-tailwindcss: 3.8.3_tailwindcss@3.2.7
+  lodash.throttle: 4.1.1
   mailing: 0.9.10_yon33puevdjlwlu7ifz3sm5xe4
   postcss: 8.4.21
   prettier: 2.8.4
@@ -1082,6 +1086,12 @@ packages:
       '@types/keygrip': 1.0.2
       '@types/koa-compose': 3.2.5
       '@types/node': 18.11.15
+    dev: true
+
+  /@types/lodash.throttle/4.1.7:
+    resolution: {integrity: sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==}
+    dependencies:
+      '@types/lodash': 4.14.191
     dev: true
 
   /@types/lodash/4.14.191:
@@ -3495,6 +3505,10 @@ packages:
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  /lodash.throttle/4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+    dev: true
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,19 @@ module.exports = {
         '-xs': { max: '428px' },
         // => @media (max-width: 639px) { ... }
       },
+
+      // Transitions
+      keyframes: {
+        // Scale Y from 0 to 1
+        'scale-y': {
+          '0%': { transform: 'scaleY(0)' },
+          '100%': { transform: 'scaleY(1)' },
+        },
+      },
+      animation: {
+        // Scale Y from 0 to 1
+        'scale-y': 'scale-y 0.3s ease-in-out',
+      }
     },
   },
   plugins: [


### PR DESCRIPTION
The scroll event is fired every time the document view or an element has been scrolled. This is a very expensive operation and can cause performance issues, especially on mobile devices.

This commit adds lodash.throttle to limit the number of times the scroll event is fired.