### PR TITLE
Add a scrollbar to the messages list

### DIFF
--- a/components/chat/messages.tsx
+++ b/components/chat/messages.tsx
@@ -81,20 +81,19 @@ export default function Messages() {
         // console.log('Scrolled to unknown');
         setOverlay(prev => ({ top: false, bottom: false }));
       }
-
-      console.log('Re-rendering')
     }, 500);
     target.addEventListener('scroll', handleScroll);
     return () => target.removeEventListener('scroll', handleScroll);
   }, []);
 
   return (
-    <div className="relative h-full overflow-hidden">
-      <div className="h-full overflow-y-auto scrollbar-hide" ref={ref}>
-        <ul className="flex flex-col justify-end divide-y divide-gray-200">
-          {messages.map((message, index) => (
-            <li key={index}>
+    <div className="relative h-full w-full">
+      <div className="flex h-full flex-col items-stretch justify-end self-auto overflow-y-hidden scrollbar-hide">
+        <div className="flex-initial overflow-y-auto scrollbar-hide" ref={ref}>
+          <div className="divide-y divide-gray-200">
+            {messages.map((message, index) => (
               <div
+                key={message.id}
                 className={cn(
                   'flex flex-col p-2',
                   data?.user?.email === message.sender && 'items-end'
@@ -112,9 +111,9 @@ export default function Messages() {
                 </p>
                 <p className="font-medium">{message.message}</p>
               </div>
-            </li>
-          ))}
-        </ul>
+            ))}
+          </div>
+        </div>
       </div>
       <div
         aria-label="Messages overflow overlay"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,19 +30,6 @@ module.exports = {
         '-xs': { max: '428px' },
         // => @media (max-width: 639px) { ... }
       },
-
-      // Transitions
-      keyframes: {
-        // Scale Y from 0 to 1
-        'scale-y': {
-          '0%': { transform: 'scaleY(0)' },
-          '100%': { transform: 'scaleY(1)' },
-        },
-      },
-      animation: {
-        // Scale Y from 0 to 1
-        'scale-y': 'scale-y 0.3s ease-in-out',
-      }
     },
   },
   plugins: [


### PR DESCRIPTION
The messages list was overflowing the chat window, and the scrollbar was hidden. This commit adds a scrollbar to the messages list.

The scrollbar is hidden by default, and only appears when the user scrolls the messages list.